### PR TITLE
Enhance SEO metadata for guru pages

### DIFF
--- a/src/components/SubscribeForm.jsx
+++ b/src/components/SubscribeForm.jsx
@@ -56,6 +56,7 @@ const SubscribeForm = () => {
       }, 3000)
       
     } catch (error) {
+      console.error('订阅失败', error)
       setStatus('error')
       setMessage('订阅失败，请稍后重试')
     }

--- a/src/hooks/useSeo.js
+++ b/src/hooks/useSeo.js
@@ -1,0 +1,158 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+const ensureMetaTag = (attribute, value) => {
+  let element = document.head.querySelector(`meta[${attribute}="${value}"]`)
+  let existed = true
+
+  if (!element) {
+    element = document.createElement('meta')
+    element.setAttribute(attribute, value)
+    document.head.appendChild(element)
+    existed = false
+  }
+
+  return { element, existed }
+}
+
+const ensureLinkTag = (rel) => {
+  let element = document.head.querySelector(`link[rel="${rel}"]`)
+  let existed = true
+
+  if (!element) {
+    element = document.createElement('link')
+    element.setAttribute('rel', rel)
+    document.head.appendChild(element)
+    existed = false
+  }
+
+  return { element, existed }
+}
+
+export const useSeo = (config) => {
+  const location = useLocation()
+
+  useEffect(() => {
+    if (!config) return undefined
+
+    const { title, description, keywords, structuredData, openGraph } = config
+    const cleanups = []
+
+    const { canonicalUrl, currentUrl } = (() => {
+      if (typeof window === 'undefined') {
+        return { canonicalUrl: '', currentUrl: '' }
+      }
+
+      const origin = window.location.origin
+      const canonicalPath = location.pathname.endsWith('/') && location.pathname !== '/'
+        ? location.pathname.slice(0, -1)
+        : location.pathname || '/'
+      const canonical = `${origin}${canonicalPath}`
+      const current = `${canonical}${location.search || ''}${location.hash || ''}`
+      return { canonicalUrl: canonical, currentUrl: current }
+    })()
+
+    if (title) {
+      const previousTitle = document.title
+      document.title = title
+      cleanups.push(() => {
+        document.title = previousTitle
+      })
+    }
+
+    const updateMetaTag = (attribute, value, content) => {
+      if (!content) return
+
+      const { element, existed } = ensureMetaTag(attribute, value)
+      const previousContent = element.getAttribute('content')
+      element.setAttribute('content', content)
+
+      cleanups.push(() => {
+        if (existed) {
+          if (previousContent !== null) {
+            element.setAttribute('content', previousContent)
+          } else {
+            element.removeAttribute('content')
+          }
+        } else {
+          element.remove()
+        }
+      })
+    }
+
+    if (description) {
+      updateMetaTag('name', 'description', description)
+    }
+
+    if (keywords) {
+      updateMetaTag('name', 'keywords', keywords)
+    }
+
+    const ogConfig = {
+      type: 'website',
+      title,
+      description,
+      url: currentUrl,
+      ...(openGraph || {})
+    }
+
+    Object.entries(ogConfig).forEach(([key, value]) => {
+      if (value) {
+        updateMetaTag('property', `og:${key}`, value)
+      }
+    })
+
+    updateMetaTag('name', 'twitter:card', 'summary_large_image')
+    if (title) {
+      updateMetaTag('name', 'twitter:title', title)
+    }
+    if (description) {
+      updateMetaTag('name', 'twitter:description', description)
+    }
+
+    if (canonicalUrl) {
+      const { element, existed } = ensureLinkTag('canonical')
+      const previousHref = element.getAttribute('href')
+      element.setAttribute('href', canonicalUrl)
+
+      cleanups.push(() => {
+        if (existed) {
+          if (previousHref !== null) {
+            element.setAttribute('href', previousHref)
+          } else {
+            element.removeAttribute('href')
+          }
+        } else {
+          element.remove()
+        }
+      })
+    }
+
+    if (structuredData) {
+      const data = typeof structuredData === 'function'
+        ? structuredData({ canonicalUrl })
+        : structuredData
+
+      if (data) {
+        const script = document.createElement('script')
+        script.setAttribute('type', 'application/ld+json')
+        script.setAttribute('data-seo', 'structured-data')
+        script.text = JSON.stringify(data)
+        document.head.appendChild(script)
+
+        cleanups.push(() => {
+          script.remove()
+        })
+      }
+    }
+
+    return () => {
+      while (cleanups.length > 0) {
+        const cleanup = cleanups.pop()
+        cleanup()
+      }
+    }
+  }, [config, location.pathname, location.search, location.hash])
+}
+
+export default useSeo

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,8 +1,30 @@
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { ChartBarIcon, ArrowTrendingUpIcon, DocumentTextIcon } from '@heroicons/react/24/outline'
 import SubscribeForm from '../components/SubscribeForm'
+import { useSeo } from '../hooks/useSeo'
 
 const HomePage = () => {
+  const seoConfig = useMemo(() => ({
+    title: '大师持仓追踪｜巴菲特与李录最新13F持仓及AI摘要',
+    description: '大师持仓追踪为你整理沃伦·巴菲特与李录最新的美股13F持仓数据，结合可视化图表与AI智能摘要，帮助投资者快速理解大师的核心持仓与季度变动。',
+    keywords: '巴菲特持仓,李录持仓,13F 报告,美股持仓数据,价值投资,投资大师',
+    structuredData: ({ canonicalUrl }) => ({
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: '大师持仓追踪',
+      url: canonicalUrl,
+      description: '追踪投资大师巴菲特与李录的美股持仓变化，提供AI摘要与可视化分析。',
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: `${canonicalUrl}?q={search_term_string}`,
+        'query-input': 'required name=search_term_string'
+      }
+    })
+  }), [])
+
+  useSeo(seoConfig)
+
   const gurus = [
     {
       id: 'buffett',


### PR DESCRIPTION
## Summary
- add a reusable `useSeo` hook to manage document metadata, canonical URLs, and structured data
- configure SEO metadata and JSON-LD schema for the homepage and holdings detail pages
- log subscription failures to surface API errors in the console

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd74f1d1d0832eab0e0f43ed4d810d