### PR TITLE
Remove deployment success banner from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>大师持仓追踪 - 追踪巴菲特和李录的投资持仓变化111111111111</title>
+    <title>大师持仓追踪 - 追踪巴菲特和李录的投资持仓变化</title>
     <meta name="description" content="专业追踪投资大师巴菲特和李录的美股持仓变化，基于SEC 13F报告提供实时数据分析和AI智能摘要，帮助投资者了解大师投资策略。">
     <meta name="keywords" content="巴菲特持仓,李录投资,美股持仓,SEC 13F,投资追踪,股票分析,价值投资">
     <meta name="author" content="大师持仓追踪">
@@ -41,14 +41,6 @@
             margin-bottom: 2rem;
         }
 
-        .success {
-            background: #10b981;
-            color: white;
-            padding: 1rem;
-            border-radius: 8px;
-            text-align: center;
-            margin: 1rem 0;
-        }
         .guru-cards {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
@@ -167,16 +159,10 @@
     </style>
 </head>
 <body>
-
-    
     <div class="container">
         <h1>追踪投资大师的持仓变化</h1>
         <p class="description">聚焦巴菲特和李录，展示最近3个季度的美股持仓变化</p>
         
-        <div class="success">
-            ✅ 网站已部署成功！开始追踪投资大师的持仓变化
-        </div>
-
         <!-- 投资大师卡片 -->
         <div class="guru-cards">
             <div class="guru-card">
@@ -198,7 +184,7 @@
                     </div>
                 </div>
                 <p style="color: #6b7280; font-size: 0.875rem; margin: 1rem 0;">
-                    股神巴菲特，价值投资的代表人物，以长期持有优质公司股票而闻名。
+                    股神巴菲特，价值投资的代表人物，以长期持有优质公司股票而闻名，凭借对企业内在价值的深入洞察和严格的投资纪律，带领伯克希尔·哈撒韦持续创造复利奇迹。
                 </p>
                 <button class="view-button" onclick="showHoldings('buffett')">查看持仓详情</button>
             </div>


### PR DESCRIPTION
## Summary
- remove the temporary deployment success banner from the static homepage
- clean up the unused CSS for the removed banner
- tidy the homepage markup so there isn’t blank space where the banner used to sit
- correct the homepage `<title>` so it no longer includes placeholder digits
- expand沃伦·巴菲特介绍语句，让主页文案更详实

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdfdded8b0832ea541032ad957f70c