### PR TITLE
Handle SubscribeForm when localStorage is unavailable

### DIFF
--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -71,7 +71,9 @@ const translationResources = {
         invalid: 'Please enter a valid email address.',
         exists: 'This email is already subscribed.',
         success: 'Subscription successful! We will email you after each quarterly update.',
-        failure: 'Subscription failed. Please try again later.'
+        failure: 'Subscription failed. Please try again later.',
+        storageUnavailable:
+          'We could not access your browser storage. Please enable local storage to subscribe.'
       },
       promise: 'We respect your inbox and you can unsubscribe at any time.',
       subscriberCount: '{{count}} investors have subscribed.'
@@ -205,7 +207,8 @@ const translationResources = {
         invalid: '请输入有效的邮箱地址。',
         exists: '该邮箱已经订阅过了。',
         success: '订阅成功！每次季度更新后我们都会通知您。',
-        failure: '订阅失败，请稍后重试。'
+        failure: '订阅失败，请稍后重试。',
+        storageUnavailable: '无法访问您的浏览器存储，请启用本地存储后再试。'
       },
       promise: '我们承诺不会发送垃圾邮件，您可以随时取消订阅。',
       subscriberCount: '已有 {{count}} 位投资者订阅。'


### PR DESCRIPTION
## Summary
- guard the SubscribeForm localStorage usage with safe helpers so the subscriber count loads without crashing when storage access fails
- surface a user-facing storage error message and localized copy when reads or writes cannot complete

## Testing
- npm run lint
- Verified the homepage renders when localStorage access throws (Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68cec172047c832e961d65ac95e3de9e