### PR TITLE
Fix static index metadata and support offline builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Guru Holdings Tracker111</title>
+    <title>Guru Holdings Tracker</title>
     <meta
       name="description"
       content="Track Warren Buffett and Li Lu portfolio changes over the latest four quarters with localized insights, charts, and AI commentary."
@@ -17,9 +17,12 @@
     <meta property="og:url" content="https://www.guruholdings.net/" />
     <meta property="og:locale" content="en_US" />
     <link rel="canonical" href="https://www.guruholdings.net/" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
   </head>
   <body>
+    <noscript>
+      <strong>请启用 JavaScript 以查看 Guru Holdings Tracker 的完整内容。</strong>
+    </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { readStorageValue, writeStorageValue } from '../utils/storage.js'
 
 const translationResources = {
   en: {
@@ -71,7 +72,9 @@ const translationResources = {
         invalid: 'Please enter a valid email address.',
         exists: 'This email is already subscribed.',
         success: 'Subscription successful! We will email you after each quarterly update.',
-        failure: 'Subscription failed. Please try again later.'
+        failure: 'Subscription failed. Please try again later.',
+        storageUnavailable:
+          'We could not access your browser storage. Please enable local storage to subscribe.'
       },
       promise: 'We respect your inbox and you can unsubscribe at any time.',
       subscriberCount: '{{count}} investors have subscribed.'
@@ -205,7 +208,8 @@ const translationResources = {
         invalid: '请输入有效的邮箱地址。',
         exists: '该邮箱已经订阅过了。',
         success: '订阅成功！每次季度更新后我们都会通知您。',
-        failure: '订阅失败，请稍后重试。'
+        failure: '订阅失败，请稍后重试。',
+        storageUnavailable: '无法访问您的浏览器存储，请启用本地存储后再试。'
       },
       promise: '我们承诺不会发送垃圾邮件，您可以随时取消订阅。',
       subscriberCount: '已有 {{count}} 位投资者订阅。'
@@ -304,29 +308,20 @@ const formatQuarter = (quarter, language) => {
 
 export const LanguageProvider = ({ children }) => {
   const [language, setLanguage] = useState(() => {
-    if (typeof window === 'undefined') {
-      return 'en'
+    const { value, error } = readStorageValue('app-language')
+
+    if (error && typeof window !== 'undefined') {
+      console.warn('[language] unable to access localStorage, defaulting to English', error)
     }
 
-    try {
-      const stored = window.localStorage.getItem('app-language')
-      return stored === 'zh' ? 'zh' : 'en'
-    } catch (error) {
-      console.warn('[language] unable to access localStorage, defaulting to English', error)
-      return 'en'
-    }
+    return value === 'zh' ? 'zh' : 'en'
   })
 
   useEffect(() => {
-    if (typeof window === 'undefined') {
-      return
-    }
+    const { success, error } = writeStorageValue('app-language', language)
 
-    try {
-      window.localStorage.setItem('app-language', language)
-    } catch (error) {
+    if (!success && error) {
       console.warn('[language] unable to persist preference', error)
-
     }
   }, [language])
 

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,65 @@
+const unavailableError = new Error('localStorage is unavailable')
+
+const resolveStorage = () => {
+  if (typeof window === 'undefined') {
+    return { storage: null, error: unavailableError }
+  }
+
+  try {
+    return { storage: window.localStorage, error: null }
+  } catch (error) {
+    return { storage: null, error }
+  }
+}
+
+export const readStorageValue = (key) => {
+  const { storage, error } = resolveStorage()
+
+  if (!storage) {
+    return { value: null, error }
+  }
+
+  try {
+    return { value: storage.getItem(key), error: null }
+  } catch (readError) {
+    return { value: null, error: readError }
+  }
+}
+
+export const writeStorageValue = (key, value) => {
+  const { storage, error } = resolveStorage()
+
+  if (!storage) {
+    return { success: false, error }
+  }
+
+  try {
+    storage.setItem(key, typeof value === 'string' ? value : String(value))
+    return { success: true, error: null }
+  } catch (writeError) {
+    return { success: false, error: writeError }
+  }
+}
+
+export const readStorageJSON = (key, fallbackValue) => {
+  const { value, error } = readStorageValue(key)
+
+  if (error || value === null) {
+    return { value: fallbackValue, error }
+  }
+
+  try {
+    return { value: JSON.parse(value), error: null }
+  } catch (parseError) {
+    return { value: fallbackValue, error: parseError }
+  }
+}
+
+export const writeStorageJSON = (key, data) => {
+  try {
+    const serialized = JSON.stringify(data)
+    return writeStorageValue(key, serialized)
+  } catch (stringifyError) {
+    return { success: false, error: stringifyError }
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,9 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  base: './',
   build: {
     outDir: 'dist',
-    assetsDir: 'assets',
+    assetsDir: 'assets'
   }
 })


### PR DESCRIPTION
## Summary
- remove the placeholder suffix from the HTML title and add a `<noscript>` notice so users understand why the page stays blank when scripts cannot run
- switch the favicon link to a relative path to match static hosting expectations
- configure Vite with a relative base path so `dist/index.html` can be opened directly without missing asset errors

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cec172047c832e961d65ac95e3de9e