### PR TITLE
Set Vite base path to absolute root

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: process.env.NODE_ENV === 'production' ? './' : '/',
+  base: '/',
   build: {
     outDir: 'dist',
     assetsDir: 'assets'


### PR DESCRIPTION
## Summary
- update the Vite configuration to always emit asset URLs from the site root

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cedfe61f54832e8c196867d0473ad2