### PR TITLE
Add Buffett resources section to holdings page

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'node_modules', 'assets']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -96,6 +96,17 @@ const translationResources = {
         currentAllocation: 'Current allocation',
         totalValueTrend: 'Total value trend'
       },
+      resources: {
+        title: 'Primary sources',
+        shareholderLetters: {
+          title: 'Shareholder letters',
+          subtitle: 'Official annual letters to Berkshire Hathaway shareholders.'
+        },
+        meetingTranscripts: {
+          title: 'Annual meeting transcripts',
+          subtitle: 'Read the full Q&A from Berkshire Hathaway annual meetings.'
+        }
+      },
       dataNotice: {
         title: 'Data notes',
         items: [
@@ -230,6 +241,17 @@ const translationResources = {
       charts: {
         currentAllocation: '当前持仓分布',
         totalValueTrend: '总市值趋势'
+      },
+      resources: {
+        title: '原始资料',
+        shareholderLetters: {
+          title: '股东信',
+          subtitle: '伯克希尔·哈撒韦官方每年致股东公开信。'
+        },
+        meetingTranscripts: {
+          title: '股东大会问答实录',
+          subtitle: '查看伯克希尔·哈撒韦股东大会的完整问答内容。'
+        }
       },
       dataNotice: {
         title: '数据说明',

--- a/src/data/buffett.js
+++ b/src/data/buffett.js
@@ -263,7 +263,85 @@ const buffettData = {
         }
       }
     }
-  ]
+  ],
+  resources: {
+    shareholderLetters: [
+      {
+        year: 2023,
+        title: {
+          en: '2023 Shareholder Letter',
+          zh: '2023年致股东信'
+        },
+        description: {
+          en: 'Buffett reflects on Berkshire’s performance and capital allocation during 2023.',
+          zh: '巴菲特回顾伯克希尔在2023年的经营表现与资本配置策略。'
+        },
+        url: 'https://www.berkshirehathaway.com/letters/2023ltr.pdf'
+      },
+      {
+        year: 2022,
+        title: {
+          en: '2022 Shareholder Letter',
+          zh: '2022年致股东信'
+        },
+        description: {
+          en: 'Highlights the resilience of Berkshire’s operating companies and investment discipline.',
+          zh: '强调伯克希尔旗下运营公司与投资策略在2022年的韧性。'
+        },
+        url: 'https://www.berkshirehathaway.com/letters/2022ltr.pdf'
+      },
+      {
+        year: 2021,
+        title: {
+          en: '2021 Shareholder Letter',
+          zh: '2021年致股东信'
+        },
+        description: {
+          en: 'Discusses Berkshire’s buyback program and long-term investment philosophy.',
+          zh: '讨论伯克希尔的股份回购计划与长期投资理念。'
+        },
+        url: 'https://www.berkshirehathaway.com/letters/2021ltr.pdf'
+      }
+    ],
+    meetingTranscripts: [
+      {
+        year: 2024,
+        title: {
+          en: '2024 Annual Meeting Transcript',
+          zh: '2024年股东大会问答实录'
+        },
+        description: {
+          en: 'Full Q&A from the 2024 Berkshire Hathaway annual meeting in Omaha.',
+          zh: '2024年伯克希尔股东大会完整问答实录，来自奥马哈现场。'
+        },
+        url: 'https://www.berkshirehathaway.com/meetings/2024/2024meetingtranscript.pdf'
+      },
+      {
+        year: 2023,
+        title: {
+          en: '2023 Annual Meeting Transcript',
+          zh: '2023年股东大会问答实录'
+        },
+        description: {
+          en: 'Detailed discussion of Berkshire’s holdings, insurance operations, and market outlook.',
+          zh: '详尽记录伯克希尔在持仓、保险业务及市场展望方面的讨论。'
+        },
+        url: 'https://www.berkshirehathaway.com/meetings/2023/2023meetingtranscript.pdf'
+      },
+      {
+        year: 2022,
+        title: {
+          en: '2022 Annual Meeting Transcript',
+          zh: '2022年股东大会问答实录'
+        },
+        description: {
+          en: 'Covers Buffett and Munger’s commentary on inflation, buybacks, and market volatility.',
+          zh: '涵盖巴菲特与芒格对通胀、回购及市场波动的观点。'
+        },
+        url: 'https://www.berkshirehathaway.com/meetings/2022/2022meetingtranscript.pdf'
+      }
+    ]
+  }
 }
 
 export default buffettData

--- a/src/hooks/useHoldingsData.js
+++ b/src/hooks/useHoldingsData.js
@@ -71,6 +71,15 @@ const transformGuruData = (rawData, { localizeText, formatQuarterLabel, t }) => 
   })
 
   const insights = rawData.insights || {}
+  const resources = rawData.resources || {}
+
+  const mapResourceItems = (items = []) =>
+    items.map((item) => ({
+      year: item.year,
+      title: localizeText(item.title) ?? '',
+      description: localizeText(item.description) ?? '',
+      url: item.url
+    }))
 
   return {
     id: rawData.id,
@@ -95,7 +104,15 @@ const transformGuruData = (rawData, { localizeText, formatQuarterLabel, t }) => 
     },
     valueHistory,
     holdings,
-    quarters: lastFourQuartersDesc
+    quarters: lastFourQuartersDesc,
+    resources: {
+      shareholderLetters: Array.isArray(resources.shareholderLetters)
+        ? mapResourceItems(resources.shareholderLetters)
+        : [],
+      meetingTranscripts: Array.isArray(resources.meetingTranscripts)
+        ? mapResourceItems(resources.meetingTranscripts)
+        : []
+    }
   }
 }
 

--- a/src/pages/HoldingsPage.jsx
+++ b/src/pages/HoldingsPage.jsx
@@ -87,6 +87,10 @@ const HoldingsPage = () => {
     )
   }
 
+  const shareholderLetters = data.resources?.shareholderLetters ?? []
+  const meetingTranscripts = data.resources?.meetingTranscripts ?? []
+  const hasResources = shareholderLetters.length > 0 || meetingTranscripts.length > 0
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -162,6 +166,74 @@ const HoldingsPage = () => {
       <div className="mb-8">
         <HoldingsTable holdings={data.holdings} quarters={data.quarters} />
       </div>
+
+      {/* Resources */}
+      {hasResources && (
+        <div className="mb-8">
+          <div className="bg-white border border-gray-200 rounded-lg p-6">
+            <h2 className="text-2xl font-bold text-gray-900 mb-6">
+              {t('holdingsPage.resources.title')}
+            </h2>
+            <div className="grid gap-6 md:grid-cols-2">
+              {shareholderLetters.length > 0 && (
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">
+                    {t('holdingsPage.resources.shareholderLetters.title')}
+                  </h3>
+                  <p className="text-sm text-gray-600 mb-4">
+                    {t('holdingsPage.resources.shareholderLetters.subtitle')}
+                  </p>
+                  <ul className="space-y-3">
+                    {shareholderLetters.map((item) => (
+                      <li key={`shareholder-${item.year}`} className="space-y-1">
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 hover:text-blue-800 font-medium"
+                        >
+                          {item.year} · {item.title}
+                        </a>
+                        {item.description && (
+                          <p className="text-sm text-gray-500">{item.description}</p>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {meetingTranscripts.length > 0 && (
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">
+                    {t('holdingsPage.resources.meetingTranscripts.title')}
+                  </h3>
+                  <p className="text-sm text-gray-600 mb-4">
+                    {t('holdingsPage.resources.meetingTranscripts.subtitle')}
+                  </p>
+                  <ul className="space-y-3">
+                    {meetingTranscripts.map((item) => (
+                      <li key={`meeting-${item.year}`} className="space-y-1">
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 hover:text-blue-800 font-medium"
+                        >
+                          {item.year} · {item.title}
+                        </a>
+                        {item.description && (
+                          <p className="text-sm text-gray-500">{item.description}</p>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Data Source Notice */}
       <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">


### PR DESCRIPTION
## Summary
- add shareholder letter and meeting transcript resources to Buffett data and surface them through the holdings hook
- localize new resources labels in both English and Chinese and render a dedicated resources section on the holdings page
- ignore build and dependency directories in ESLint config so linting excludes bundled assets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf5bae8d90832e861e2844b7d104e7